### PR TITLE
Update Networkx to 2.6.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,7 +78,7 @@ about:
     NetworkX is a Python language software package for the creation,
     manipulation, and study of the structure, dynamics, and functions of complex
     networks.
-  doc_url: http://networkx.github.io/documentation.html
+  doc_url: https://networkx.org/documentation/stable
   dev_url: https://github.com/networkx/networkx
   doc_source_url: https://github.com/networkx/networkx/blob/v1.11/doc/source/index.rst
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.6.2" %}
+{% set version = "2.6.3" %}
 
 package:
   name: networkx
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/networkx/networkx-{{ version }}.tar.gz
-  sha256: 2306f1950ce772c5a59a57f5486d59bb9cab98497c45fc49cbc45ac0dec119bb
+  sha256: c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51
 
 build:
   number: 0


### PR DESCRIPTION
1. check the upstream
2. check the pinnings
3. verify the changelogs

   https://github.com/networkx/networkx/blob/main/doc/release/release_2.6.rst 
   
   there were some potentially breaking changes mentioned on the  release section

   Dropped "decorator" library dependency
   Removed code for supporting Jython/IronPython

   Other deprecated

   The rest of the changes were bug fixes and additions
4. verify dev_url
5. had to update the doc_url since the link was broken
     https://networkx.org/documentation/stable/index.html
6. verify that pip is checked
7. verify that wheel is present
8. verify the test section
9. additional research 

there are no resent open issues reported in conda-forge
https://github.com/conda-forge/networkx-feedstock/issues

10. additional tests
 
    The commands used for the initial testing `conda-build networkx-feedstock --test` 
    The result was the following `All tests passed`

   In addition, we will test the package by using a package that has `networkx` in this context we will use `mapclassify`
   The meta.yaml file will be modified by specifying the pinning for `networkx` after making the modifications the test is run
   The command used to test the `mapclassify` is the following `conda-build mapclassify-feedstock --test`
   The result is the following `All tests passed`

Based on our research and tests results we can conclude that it is relatively safe to update `networkx` to version 2.6.3


    