### PR TITLE
networkx 2.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.6.3" %}
+{% set version = "2.7.1" %}
 
 package:
   name: networkx
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/networkx/networkx-{{ version }}.tar.gz
-  sha256: c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51
+  sha256: d1194ba753e5eed07cdecd1d23c5cd7a3c772099bd8dbd2fea366788cf4de7ba
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
+{% set name = "networkx" %}
 {% set version = "2.7.1" %}
 
 package:
-  name: networkx
-  # Versions 2.6, 2.6.1 have been yanked https://pypi.org/project/networkx/#history
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/networkx/networkx-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d1194ba753e5eed07cdecd1d23c5cd7a3c772099bd8dbd2fea366788cf4de7ba
-
 build:
   number: 0
   noarch: python
@@ -16,19 +15,19 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.7
+    - python >=3.8
     # 2021/7/28: Optional dependencies numpy, scipy, matplotlib, pandas,
     # but they can cause issues when try to build scipy or pythran,
     # see https://github.com/networkx/networkx/commit/5b86d913117ee22d9522755d607b5c6256cd57b9
     #- numpy >=1.19
-    #- scipy >=1.5,!=1.6.1
-    #- matplotlib >=3.3
-    #- pandas >=1.1
+    #- scipy >=1.8
+    #- matplotlib >=3.4
+    #- pandas >=1.3
     # Optional lxml, pygraphviz, pydot, gdal packages provide additional functionality
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,10 @@ test:
     - pip
   commands:
     - pip check
+  downstreams:
+    - pythran
+    - scikit-image
+    - pomegranate
 
 about:
   home: https://networkx.github.io/


### PR DESCRIPTION
Update networkx to 2.7.1

Bug Tracker: new open issues https://github.com/networkx/networkx/issues
Upstream license: https://github.com/networkx/networkx/blob/main/LICENSE.txt
Changelog: https://github.com/networkx/networkx/blob/networkx-2.7.1/INSTALL.rst
Upstream setup.py: https://github.com/networkx/networkx/blob/networkx-2.7.1/setup.py and optional dependencies https://github.com/networkx/networkx/blob/networkx-2.7.1/requirements/default.txt

The package networkx is mentioned inside the packages:
caffe | caffe-gpu | cfn-lint | mapclassify | networkx-1.11 | odo | orange3 | pomegranate | pygraphviz | python-louvain | pythran | scikit-image | scikit-rf | visions | 

Actions:
1. Use jinja2 templates for source/url
2. Fix python in host
3. Update python to >=3.8. in run
4. Add `downstreams` for additional testing: `pythran`, `scikit-image`, `pomegranate`

Result:
- all-succeeded