### PR TITLE
networkx 2.8.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,8 +60,6 @@ test:
     - networkx.tests
     - networkx.testing
     - networkx.utils
-  sourse_files:
-    - tests/
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,10 +64,10 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - pythran
-    - scikit-image
-    - pomegranate
+  #downstreams:
+  #  - pythran
+  #  - scikit-image
+  #  - pomegranate
 
 about:
   home: https://networkx.github.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "networkx" %}
-{% set version = "2.7.1" %}
+{% set version = "2.8.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d1194ba753e5eed07cdecd1d23c5cd7a3c772099bd8dbd2fea366788cf4de7ba
+  sha256: 5e53f027c0d567cf1f884dbb283224df525644e43afd1145d64c9d88a3584762
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.8
+    - python
     # 2021/7/28: Optional dependencies numpy, scipy, matplotlib, pandas,
     # but they can cause issues when try to build scipy or pythran,
     # see https://github.com/networkx/networkx/commit/5b86d913117ee22d9522755d607b5c6256cd57b9


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/networkx/networkx/issues
License: https://github.com/networkx/networkx/blob/main/LICENSE.txt
Requirements: 
- https://github.com/networkx/networkx/blob/networkx-2.8.4/INSTALL.rst
- https://github.com/networkx/networkx/blob/networkx-2.8.4/setup.py 
- optional dependencies https://github.com/networkx/networkx/blob/networkx-2.8.4/requirements/default.txt

The package networkx is mentioned inside the packages:
caffe | caffe-gpu | cfn-lint | mapclassify | odo | orange3 | pomegranate | pygraphviz | python-louvain | pythran | scikit-image | scikit-rf | visions |

Actions:
1. Skip `py<38`
2. Fix `python` in `run`
3. Remove unused `test/source_files`
4. Disable `downstreams`