### PR TITLE
V3.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ requirements:
     - wheel
   run:
     - python
-
-    # Serhii:
     # 2021/7/28: Optional dependencies numpy, scipy, matplotlib, pandas,
     # but they can cause issues when try to build scipy or pythran,
     # see https://github.com/networkx/networkx/commit/5b86d913117ee22d9522755d607b5c6256cd57b9
@@ -31,18 +29,6 @@ requirements:
     #- matplotlib >=3.4
     #- pandas >=1.3
     # Optional lxml, pygraphviz, pydot, gdal packages provide additional functionality
-
-    # Steve:
-    # Do we want to add the following packages to this recipe?
-    - numpy >=1.20
-    - scipy >=1.8
-    - matplotlib >=3.4
-    - pandas >=1.3
-  run-constrained:
-    - lxml >=4.6
-    - pygraphviz >=1.10
-    - pydot >=1.4.2
-    - sympy >=1.10
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,15 @@ requirements:
     - wheel
   run:
     - python
-    # 2021/7/28: Optional dependencies numpy, scipy, matplotlib, pandas,
-    # but they can cause issues when try to build scipy or pythran,
-    # see https://github.com/networkx/networkx/commit/5b86d913117ee22d9522755d607b5c6256cd57b9
-    #- numpy >=1.19
-    #- scipy >=1.8
-    #- matplotlib >=3.4
-    #- pandas >=1.3
-    # Optional lxml, pygraphviz, pydot, gdal packages provide additional functionality
+  run-constrained:
+    - numpy >=1.20
+    - scipy >=1.8
+    - matplotlib >=3.4
+    - pandas >=1.3
+    - lxml >=4.6
+    - pygraphviz >=1.10
+    - pydot >=1.4.2
+    - sympy >=1.10
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "networkx" %}
-{% set version = "2.8.4" %}
+{% set version = "3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5e53f027c0d567cf1f884dbb283224df525644e43afd1145d64c9d88a3584762
+  sha256: de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61
 build:
   number: 1
   skip: True  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 1
   skip: True  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vvv --no-deps
+  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -46,7 +46,6 @@ test:
     - networkx.algorithms.isomorphism
     - networkx.algorithms.link_analysis
     - networkx.algorithms.minors
-    - networkx.algorithms.node_classification
     - networkx.algorithms.operators
     - networkx.algorithms.shortest_paths
     - networkx.algorithms.traversal
@@ -58,7 +57,6 @@ test:
     - networkx.readwrite
     - networkx.readwrite.json_graph
     - networkx.tests
-    - networkx.testing
     - networkx.utils
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,15 @@ requirements:
     #- matplotlib >=3.4
     #- pandas >=1.3
     # Optional lxml, pygraphviz, pydot, gdal packages provide additional functionality
+    - numpy >=1.20
+    - scipy >=1.8
+    - matplotlib >=3.4
+    - pandas >=1.3
+  run-constrained:
+    - lxml >=4.6
+    - pygraphviz >=1.10
+    - pydot >=1.4.2
+    - sympy >=1.10
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61
 build:
-  number: 1
+  number: 0
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
     - wheel
   run:
     - python
+
+    # Serhii:
     # 2021/7/28: Optional dependencies numpy, scipy, matplotlib, pandas,
     # but they can cause issues when try to build scipy or pythran,
     # see https://github.com/networkx/networkx/commit/5b86d913117ee22d9522755d607b5c6256cd57b9
@@ -29,6 +31,9 @@ requirements:
     #- matplotlib >=3.4
     #- pandas >=1.3
     # Optional lxml, pygraphviz, pydot, gdal packages provide additional functionality
+
+    # Steve:
+    # Do we want to add the following packages to this recipe?
     - numpy >=1.20
     - scipy >=1.8
     - matplotlib >=3.4


### PR DESCRIPTION
[Upstream](https://github.com/networkx/networkx/tree/networkx-3.1)
[Changelog](https://networkx.org/documentation/latest/release/release_dev.html)

## Actions
- Updated version to 3.1 (3.1.0 causes a URL error)
- Updated run script to include `--no-build-isoloation`
- Remove outdated tests
- Add required and extra packages for testing

## Questions
- Should we still leave out these required/optional packages Per the comment left in the `meta.yaml` by @skupr-anaconda?
- If so, is my formatting correct?
- I will clean up the `meta.yaml` once these questions are answered.