### PR TITLE
networkx 3.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "networkx" %}
-{% set version = "3.1" %}
+{% set version = "3.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61
+  sha256: 9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6
 build:
   number: 0
-  skip: True  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
+  skip: True  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -22,12 +22,12 @@ requirements:
   run:
     - python
   run-constrained:
-    - numpy >=1.20
-    - scipy >=1.8
-    - matplotlib >=3.4
-    - pandas >=1.3
+    - numpy >=1.22
+    - scipy >=1.9,!=1.11.0,!=1.11.1
+    - matplotlib-base >=3.5
+    - pandas >=1.4
     - lxml >=4.6
-    - pygraphviz >=1.10
+    - pygraphviz >=1.11
     - pydot >=1.4.2
     - sympy >=1.10
 
@@ -63,10 +63,11 @@ test:
     - pip
   commands:
     - pip check
-  #downstreams:
-  #  - pythran
-  #  - scikit-image
-  #  - pomegranate
+  # downstreams:
+  #   - anaconda-linter 0.1.1
+  #   - mapclassify 2.5.0
+  #   - scikit-image 0.22.0
+  #   - visions 0.7.6
 
 about:
   home: https://networkx.github.io/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4946](https://anaconda.atlassian.net/browse/PKG-4946)
- release-notes: https://github.com/networkx/networkx/releases
- release-diff: https://github.com/networkx/networkx/compare/networkx-3.1...networkx-3.2.1
- requirements-tagged:
  - https://github.com/networkx/networkx/blob/networkx-3.2.1/pyproject.toml


### Explanation of changes:

- Skip py<39
- Update dependencies' pinnings

### Notes:

- It was requested to update to v3.2.1.
- As networkx is a critical package in the users environments I've tested the downstream packages. No issues found:
```
  downstreams:
    - anaconda-linter 0.1.1
    - mapclassify 2.5.0
    - scikit-image 0.22.0
    - visions 0.7.6
```

[PKG-4946]: https://anaconda.atlassian.net/browse/PKG-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ