### PR TITLE
networkx 3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-  run-constrained:
+  run_constrained:
     - numpy >=1.23
     - scipy >=1.9,!=1.11.0,!=1.11.1
     - matplotlib-base >=3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "networkx" %}
-{% set version = "3.2.1" %}
+{% set version = "3.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6
+  sha256: 0c127d8b2f4865f59ae9cb8aafcd60b5c70f3241ebd66f7defad7c4ab90126c9
 build:
   number: 0
-  skip: True  # [py<39]
+  skip: True  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -22,13 +22,13 @@ requirements:
   run:
     - python
   run-constrained:
-    - numpy >=1.22
+    - numpy >=1.23
     - scipy >=1.9,!=1.11.0,!=1.11.1
-    - matplotlib-base >=3.5
+    - matplotlib-base >=3.6
     - pandas >=1.4
     - lxml >=4.6
-    - pygraphviz >=1.11
-    - pydot >=1.4.2
+    - pygraphviz >=1.12
+    - pydot >=2.0
     - sympy >=1.10
 
 test:
@@ -57,7 +57,6 @@ test:
     - networkx.linalg
     - networkx.readwrite
     - networkx.readwrite.json_graph
-    - networkx.tests
     - networkx.utils
   requires:
     - pip
@@ -66,7 +65,7 @@ test:
   # downstreams:
   #   - anaconda-linter 0.1.1
   #   - mapclassify 2.5.0
-  #   - scikit-image 0.22.0
+  #   - scikit-image 0.23.2
   #   - visions 0.7.6
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-  run-constrained:
+  run_constrained:
     - numpy >=1.23
     - scipy >=1.9,!=1.11.0,!=1.11.1
     - matplotlib-base >=3.6
@@ -60,8 +60,10 @@ test:
     - networkx.utils
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v --pyargs networkx
   # downstreams:
   #   - anaconda-linter 0.1.1
   #   - mapclassify 2.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ test:
   #   - visions 0.7.6
 
 about:
-  home: https://networkx.github.io/
+  home: https://networkx.org/
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD


### PR DESCRIPTION
**Destination channel:** main


### Links

- [PKG-3167](https://anaconda.atlassian.net/browse/PKG-3167)
- release-notes: https://github.com/networkx/networkx/releases
- release-notes-tagged: https://github.com/networkx/networkx/releases/tag/v3.3
- release-diff: https://github.com/networkx/networkx/compare/v3.2.1...v3.3
- license: https://github.com/networkx/networkx/blob/main/LICENSE.txt
- requirements-tagged:
  - https://github.com/networkx/networkx/blob/networkx-3.3/pyproject.toml


### Explanation of changes:

- Skip py<310
- Update run_constrained pinnings
- Remove `networkx.tests` from imports  as redundant


[PKG-3167]: https://anaconda.atlassian.net/browse/PKG-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ