### PR TITLE
networkx 3.5 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "networkx" %}
-{% set version = "3.4.2" %}
+{% set version = "3.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,8 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1
+  sha256: d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037
+
 build:
   number: 0
   skip: True  # [py<311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1
 build:
   number: 0
-  skip: True  # [py<310]
+  skip: True  # [py<311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -18,14 +18,23 @@ requirements:
     - python
     - pip
     - setuptools >=61.2
-    - wheel
   run:
     - python
   run_constrained:
-    - numpy >=1.24
-    - scipy >=1.10,!=1.11.0,!=1.11.1
-    - matplotlib-base >=3.7
+    # default
+    - numpy >=1.25
+    - scipy >=1.11.2
+    - matplotlib-base >=3.8
     - pandas >=2.0
+    # example
+    - osmnx >=2.0.0
+    - momepy >=0.7.2
+    - contextily >=1.6
+    - seaborn >=0.13
+    - cairocffi >=1.7
+    - igraph >=0.11
+    - scikit-learn >=1.5
+    # extra
     - lxml >=4.6
     - pygraphviz >=1.14
     - pydot >=3.0.1
@@ -72,7 +81,7 @@ test:
   #   - visions 0.7.6
 
 about:
-  home: https://networkx.org/
+  home: https://networkx.org
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD


### PR DESCRIPTION
networkx 3.5 

**Destination channel:** Defaults

### Links

- [PKG-9379]
- dev_url:        https://github.com/networkx/networkx/tree/networkx-3.5
- conda_forge:    https://github.com/conda-forge/networkx-feedstock
- pypi:           https://pypi.org/project/networkx/3.5
- pypi inspector: https://inspector.pypi.io/project/networkx/3.5

### Explanation of changes:

- new version number


[PKG-9379]: https://anaconda.atlassian.net/browse/PKG-9379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ